### PR TITLE
quotes are important for oracle, and possibly other databases

### DIFF
--- a/lib/lazy_columns/acts_as_lazy_column_loader.rb
+++ b/lib/lazy_columns/acts_as_lazy_column_loader.rb
@@ -13,7 +13,7 @@ module LazyColumns
       private
 
       def exclude_columns_from_default_scope(columns)
-        default_scope { select((column_names - columns).map { |column_name| "#{table_name}.#{column_name}" }) }
+        default_scope { select((column_names - columns).map { |column_name| "#{ActiveRecord::Base.connection.quote_table_name(table_name)}.#{ActiveRecord::Base.connection.quote_column_name(column_name)}" }) }
       end
 
       def define_lazy_accessors_for(columns)


### PR DESCRIPTION
nice work..with the gem.. we had to add quotes for the table & column names , for Oracle .
